### PR TITLE
`v3.2.0`

### DIFF
--- a/packages/XElement/XElement.astro
+++ b/packages/XElement/XElement.astro
@@ -1,5 +1,4 @@
 ---
-import { Fragment } from 'astro/internal'
 import { createRequire } from 'node:module'
 
 const require = createRequire(import.meta.url)

--- a/packages/XElement/package.json
+++ b/packages/XElement/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-xelement",
-  "version": "3.1.7",
+  "version": "3.2.0",
   "description": "XElement is a powerful Astro Web Component generator. Create your own Astro compliant Web Components using only HTML Elements with additional Client-Side JS/TS interactivity sprinkled into the Element.",
   "keywords": [
     "XElement",


### PR DESCRIPTION
Updated XElement to version `3.2.0`.

This fixes the `astro/internal` issue with XElement working on newer releases of Astro. 

